### PR TITLE
Wavefront tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ logs/
 models/
 replays/
 *.prof
+venv/

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ import gymnasium as gym
 from nle import nethack
 from sb3_contrib.ppo_mask import MaskablePPO
 from stable_baselines3.common.vec_env import SubprocVecEnv, VecMonitor
+from stable_baselines3.common.callbacks import BaseCallback
 
 import yndf
 
@@ -23,6 +24,31 @@ ACTIONS = MOVE_ACTIONS + DESCEND_ACTION + OTHER_ACTIONS
 ROLLOUT_TARGET = 4096
 DEFAULT_BATCH_SIZE = 1024
 
+class PeriodicCheckpointCallback(BaseCallback):
+    """Save model checkpoints every `save_every` timesteps.
+
+    Files are written to `save_dir / f"{model_name}_{num_timesteps}.zip"`.
+    """
+    def __init__(self, save_every: int, save_dir: Path, model_name: str, verbose: int = 0) -> None:
+        super().__init__(verbose=verbose)
+        self.save_every = int(save_every)
+        self.save_dir = Path(save_dir)
+        self.model_name = model_name
+        self._last_saved_step = 0
+
+    def _on_training_start(self) -> bool:
+        self.save_dir.mkdir(parents=True, exist_ok=True)
+        return True
+
+    def _on_step(self) -> bool:
+        steps = int(self.model.num_timesteps)
+        if steps - self._last_saved_step >= self.save_every:
+            path = self.save_dir / f"{self.model_name}_{steps}.zip"
+            self.model.save(str(path))
+            self._last_saved_step = steps
+            if self.verbose:
+                print(f"[checkpoint] saved {path}")
+        return True
 
 def main(
     total_timesteps: int,
@@ -64,6 +90,13 @@ def main(
     # Keep total rollout size roughly constant across different parallelism.
     n_steps_per_env = max(1, ROLLOUT_TARGET // n_envs)
     batch_size = min(DEFAULT_BATCH_SIZE, n_steps_per_env * n_envs)
+    model_file_name_base = f"nethack_{total_timesteps}"
+    save_callback = PeriodicCheckpointCallback(
+        save_every=100_000,
+        save_dir=out_path,
+        model_name=model_file_name_base,
+        verbose=1,
+    )
 
     model = MaskablePPO(
         policy=yndf.NethackMaskablePolicy,
@@ -80,8 +113,8 @@ def main(
         f"batch_size={batch_size}, output='{out_path}', logs='{log_path}'"
     )
 
-    model.learn(total_timesteps=total_timesteps, progress_bar=True)
-    model.save(str(out_path / f"ppo_nethack_nav_{total_timesteps}"))
+    model.learn(total_timesteps=total_timesteps, progress_bar=True, callback=save_callback)
+    model.save(str(out_path / model_file_name_base))
 
     print("Training finished and model saved.")
 

--- a/yndf/movement.py
+++ b/yndf/movement.py
@@ -240,6 +240,6 @@ def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, floor_glyphs: np.nda
     targets = np.argwhere((glyph_kinds == GlyphKind.EXIT.value) | (glyph_kinds == GlyphKind.FRONTIER.value))
     targets += [(y, x) for y in range(glyphs.shape[0])
                     for x in range(glyphs.shape[1])
-                    if not visited[y, x] and not nle.nethack.glyph_is_cmap(glyphs[y, x])]
+                    if not visited[y, x] and not nle.nethack.glyph_is_cmap(glyphs[y, x]) and not nle.nethack.glyph_is_monster(glyphs[y, x])]
     wavefront = calculate_wavefront(floor_glyphs, glyph_kinds, targets)
     return wavefront, glyph_kinds

--- a/yndf/movement.py
+++ b/yndf/movement.py
@@ -195,7 +195,7 @@ def calculate_glyph_kinds(glyphs: np.ndarray, visited: np.ndarray) -> np.ndarray
     # Reuse a workspace array to avoid an extra allocation:
     work = np.zeros_like(visited_bool)
     touches_unseen = _neighbors_any(unseen_and_unvisited, DIRECTIONS, out=work)
-    frontier_mask = (gk == GlyphKind.PASSABLE.value) & touches_unseen
+    frontier_mask = (gk == GlyphKind.PASSABLE.value) & touches_unseen & ~visited_bool
     gk[frontier_mask] = GlyphKind.FRONTIER.value
 
     return gk

--- a/yndf/movement.py
+++ b/yndf/movement.py
@@ -235,7 +235,6 @@ def calculate_wavefront(glyphs: np.ndarray, glyph_kinds: np.ndarray, targets: Li
 def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, floor_glyphs: np.ndarray, visited: np.ndarray) -> np.ndarray:
     """Calculate the wavefront from a NethackState and a list of target locations."""
 
-    np.where()
     glyph_kinds = calculate_glyph_kinds(floor_glyphs, visited)
     targets = np.argwhere((glyph_kinds == GlyphKind.EXIT.value) | (glyph_kinds == GlyphKind.FRONTIER.value))
     targets += [(y, x) for y in range(glyphs.shape[0])

--- a/yndf/movement.py
+++ b/yndf/movement.py
@@ -233,11 +233,19 @@ def calculate_wavefront(glyphs: np.ndarray, glyph_kinds: np.ndarray, targets: Li
     return wavefront
 
 def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, floor_glyphs: np.ndarray,
-                                        visited: np.ndarray) -> np.ndarray:
+                                        visited: np.ndarray, unpassable: List[Tuple[int, int]]) -> np.ndarray:
     """Calculate the wavefront from a NethackState and a list of target locations."""
 
     # pylint: disable=no-member
     glyph_kinds = calculate_glyph_kinds(floor_glyphs, visited)
+    # if there are impassible tiles, we need to change glyph_kinds to unpassable
+    if unpassable:
+        unpassable_mask = np.zeros(glyph_kinds.shape, dtype=bool)
+        for y, x in unpassable:
+            if 0 <= y < glyph_kinds.shape[0] and 0 <= x < glyph_kinds.shape[1]:
+                unpassable_mask[y, x] = True
+        glyph_kinds[unpassable_mask] = GlyphKind.UNPASSABLE.value
+
 
     # existing targets (shape: [N, 2])
     targets = np.argwhere(

--- a/yndf/movement.py
+++ b/yndf/movement.py
@@ -232,9 +232,14 @@ def calculate_wavefront(glyphs: np.ndarray, glyph_kinds: np.ndarray, targets: Li
 
     return wavefront
 
-def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, visited: np.ndarray) -> np.ndarray:
+def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, floor_glyphs: np.ndarray, visited: np.ndarray) -> np.ndarray:
     """Calculate the wavefront from a NethackState and a list of target locations."""
-    glyph_kinds = calculate_glyph_kinds(glyphs, visited)
+
+    np.where()
+    glyph_kinds = calculate_glyph_kinds(floor_glyphs, visited)
     targets = np.argwhere((glyph_kinds == GlyphKind.EXIT.value) | (glyph_kinds == GlyphKind.FRONTIER.value))
-    wavefront = calculate_wavefront(glyphs, glyph_kinds, targets)
+    targets += [(y, x) for y in range(glyphs.shape[0])
+                    for x in range(glyphs.shape[1])
+                    if not visited[y, x] and not nle.nethack.glyph_is_cmap(glyphs[y, x])]
+    wavefront = calculate_wavefront(floor_glyphs, glyph_kinds, targets)
     return wavefront, glyph_kinds

--- a/yndf/movement.py
+++ b/yndf/movement.py
@@ -232,10 +232,11 @@ def calculate_wavefront(glyphs: np.ndarray, glyph_kinds: np.ndarray, targets: Li
 
     return wavefront
 
-def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, floor_glyphs: np.ndarray, visited: np.ndarray) -> np.ndarray:
+def calculate_wavefront_and_glyph_kinds(glyphs: np.ndarray, floor_glyphs: np.ndarray,
+                                        visited: np.ndarray) -> np.ndarray:
     """Calculate the wavefront from a NethackState and a list of target locations."""
 
-
+    # pylint: disable=no-member
     glyph_kinds = calculate_glyph_kinds(floor_glyphs, visited)
 
     # existing targets (shape: [N, 2])

--- a/yndf/nethack_state.py
+++ b/yndf/nethack_state.py
@@ -5,7 +5,7 @@ from typing import Optional
 from nle import nethack
 import numpy as np
 
-from yndf.movement import CLOSED_DOORS, OPEN_DOORS, GlyphKind, calculate_wavefront_and_glyph_kinds
+from yndf.movement import CLOSED_DOORS, OPEN_DOORS, GlyphKind, SolidGlyphs, calculate_wavefront_and_glyph_kinds
 
 class NethackPlayer:
     """Player state in Nethack."""
@@ -243,6 +243,8 @@ class NethackState:
             for x in range(glyphs.shape[1]):
                 glyph = glyphs[y, x]
                 if nethack.glyph_is_monster(glyph) or nethack.glyph_is_object(glyph):
-                    floor_glyphs[y, x] = prev.floor_glyphs[y, x]
+                    prev_glyph = prev.floor_glyphs[y, x]
+                    if prev_glyph != SolidGlyphs.S_stone.value:
+                        floor_glyphs[y, x] = prev_glyph
 
         return floor_glyphs

--- a/yndf/nethack_state.py
+++ b/yndf/nethack_state.py
@@ -150,7 +150,7 @@ class NethackState:
 
         self.visited[self.player.position] = 1
 
-        wavefront, glyph_kinds = calculate_wavefront_and_glyph_kinds(self.floor_glyphs, self.visited)
+        wavefront, glyph_kinds = calculate_wavefront_and_glyph_kinds(self.glyphs, self.floor_glyphs, self.visited)
         self.wavefront = wavefront
         self.glyph_kinds = glyph_kinds
 

--- a/yndf/wrapper_state.py
+++ b/yndf/wrapper_state.py
@@ -41,6 +41,11 @@ class NethackStateWrapper(gym.Wrapper):
         if self._current_state.message == "You can't move diagonally out of an intact doorway.":
             self._current_state.add_open_door(self._current_state.player.position)
 
+        if self._current_state.message == "You try to move the boulder, but in vain.":
+            # If the player tried to move a boulder and can't, we need to disallow that action
+            self._current_state.add_stuck_boulder(self._current_state.player.position,
+                                                  self._get_target_position(action))
+
         return obs, reward, terminated, truncated, info
 
     def _get_target_position(self, action):


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of stuck boulders, action masking, and state management in the Nethack agent, as well as adds a periodic checkpointing callback for training. The main changes include more robust tracking and prevention of invalid boulder movements, enhancements to the reward system, and improved environment setup for training.

**Stuck boulder handling and action masking:**
- Introduced the `StuckBoulder` class and mechanisms in `NethackState` to track and manage boulders that cannot be moved, updating the state when the player attempts and fails to move a boulder. The action mask now prevents the agent from repeatedly trying to push stuck boulders. [[1]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232R132-R140) [[2]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232L146-L165) [[3]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232R235-R239) [[4]](diffhunk://#diff-8835c8965b449ba5a423706be07cfee979d04e7bac0652500398e64bf1f4ad8bR44-R48) [[5]](diffhunk://#diff-24f0ec499e9c49b12955e06e939caf80180917fe2cd7c572d1109be795af9bb6R88-R115)
- Updated the `calculate_wavefront_and_glyph_kinds` function to accept unpassable tiles (like stuck boulders), ensuring pathfinding logic treats these appropriately.

**Training and checkpointing:**
- Added a `PeriodicCheckpointCallback` to periodically save model checkpoints during training, improving reproducibility and recovery. Updated environment creation logic for better parallelism and replay saving. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R13) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R27-R51) [[3]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R74-R99) [[4]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L82-R117)

**Reward system enhancements:**
- Introduced a new `REACHED_FRONTIER` reward for reaching new areas or picking up items, encouraging exploration. [[1]](diffhunk://#diff-07865b1f44d344549a3f095c8f61979df6b3c3f55ebdf08a6323d17d5c3f2bb2R33) [[2]](diffhunk://#diff-07865b1f44d344549a3f095c8f61979df6b3c3f55ebdf08a6323d17d5c3f2bb2R88-R95)

**State and environment improvements:**
- Improved the logic for copying previous state components (like visited tiles, found exits, and locked doors) only when appropriate (i.e., on the same dungeon level).
- Enhanced floor glyph reconstruction to avoid overwriting solid tiles with monsters or objects, preserving map integrity.

**Minor fixes and refactoring:**
- Fixed the calculation of the frontier mask to avoid revisiting already visited tiles.
- Added type annotations and minor code cleanups for clarity and maintainability.

These changes collectively make the agent more robust in challenging scenarios, improve training reliability, and encourage better exploration behavior.

**References:**
- Stuck boulder and action masking: [[1]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232R132-R140) [[2]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232L146-L165) [[3]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232R235-R239) [[4]](diffhunk://#diff-8835c8965b449ba5a423706be07cfee979d04e7bac0652500398e64bf1f4ad8bR44-R48) [[5]](diffhunk://#diff-24f0ec499e9c49b12955e06e939caf80180917fe2cd7c572d1109be795af9bb6R88-R115) [[6]](diffhunk://#diff-1cdfbbb3c85ed8ae631e5ae52632d1988cb5ae9bbc0bd0b2feca87d8d3346580L235-R265)
- Training and checkpointing: [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R13) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R27-R51) [[3]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R74-R99) [[4]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L82-R117)
- Reward system: [[1]](diffhunk://#diff-07865b1f44d344549a3f095c8f61979df6b3c3f55ebdf08a6323d17d5c3f2bb2R33) [[2]](diffhunk://#diff-07865b1f44d344549a3f095c8f61979df6b3c3f55ebdf08a6323d17d5c3f2bb2R88-R95)
- State and environment: [[1]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232L146-L165) [[2]](diffhunk://#diff-df6fbca1b03273c2135b701e2b527cded0d215e61dde6844fca6e88566c47232L246-R271)
- Minor fixes: [[1]](diffhunk://#diff-1cdfbbb3c85ed8ae631e5ae52632d1988cb5ae9bbc0bd0b2feca87d8d3346580L198-R198) [[2]](diffhunk://#diff-07865b1f44d344549a3f095c8f61979df6b3c3f55ebdf08a6323d17d5c3f2bb2L78-R79)