### PR TITLE
Rework replays to only save what comes out of the raw environment

### DIFF
--- a/debugger.py
+++ b/debugger.py
@@ -43,7 +43,6 @@ class Controller(yndf.gui.NethackController):
             if x.name == "no-discovery":
                 x.disable()
 
-
     def reset(self) -> yndf.NethackState:
         """Reset the controller to the initial state and return the first frame."""
         obs, info = self.env.reset()
@@ -106,7 +105,7 @@ def main():
     )
     args = parser.parse_args()
 
-    env = gym.make("YenderFlow-v0", actions=ACTIONS)
+    env = gym.make("YenderFlow-v0", actions=ACTIONS, save_replays=True)
     yndf.gui.run_gui(Controller(env), model_path=args.model_path)
 
 if __name__ == "__main__":

--- a/yndf/__init__.py
+++ b/yndf/__init__.py
@@ -18,16 +18,14 @@ def create_env(**kwargs) -> gym.Env:
 
     actions = kwargs.get("actions", env.unwrapped.actions)
     has_search = nle.nethack.Command.SEARCH in actions
-    save_replays = kwargs.get("save_replays", False)
 
-    # todo: about to rewrite this differently so don't capture this for now
-    save_replays = False
+    if kwargs.get("save_replays", False):
+        env = NethackReplayWrapper(env)
+
     env = NethackStateWrapper(env)
     env = NethackObsWrapper(env)
     env = NethackRewardWrapper(env, has_search)
-    action_wrapper = env = NethackActionWrapper(env, actions)
-    if save_replays:
-        env = NethackReplayWrapper(env, action_wrapper)
+    env = NethackActionWrapper(env, actions)
 
     return env
 

--- a/yndf/replays.py
+++ b/yndf/replays.py
@@ -21,17 +21,12 @@ class StepRecord:
 
     Fields:
         action: integer action that was taken (keypress).
-        original_observation: dict from the NetHack env (raw).
-        model_observation: dict fed to your model (post-wrappers).
-        original_info: info dict from the NetHack env (raw).
-        model_info: info dict after your wrappers.
+        observation: observation from the NetHack env (raw).
+        info: info dict from the NetHack env (raw).
     """
     action: int
-    original_observation: Mapping[str, Any]
-    original_info: Mapping[str, Any]
-    observation: Mapping[str, Any]
-    info: Mapping[str, Any]
-
+    observation: dict[str, Any] | None
+    info: dict[str, Any] | None
 
 def _enum_name_or_value(val: Any) -> Any:
     """Convert Enum to its name, otherwise return value unchanged."""
@@ -55,12 +50,9 @@ def _sanitize_step_for_pickle(step: StepRecord) -> StepRecord:
     """
     return StepRecord(
         action=int(step.action) if step.action is not None else None,
-        original_observation=_sanitize_top_enums(step.original_observation) or {},
-        original_info=_sanitize_top_enums(step.original_info) or {},
         observation=_sanitize_top_enums(step.observation) or {},
         info=_sanitize_top_enums(step.info) or {},
     )
-
 
 # --------------------------
 # Safe, atomic replay writer

--- a/yndf/wrapper_replay.py
+++ b/yndf/wrapper_replay.py
@@ -1,44 +1,42 @@
 from typing import List
 import gymnasium as gym
-from yndf.nethack_state import NethackState
 from yndf.replays import save_replay
-from yndf.wrapper_actions import NethackActionWrapper
 from yndf.replays import StepRecord
 
 class NethackReplayWrapper(gym.Wrapper):
     """Wraps the environment to save replays of the game steps."""
 
-    def __init__(self, env: gym.Env, action_wrapper: NethackActionWrapper) -> None:
+    def __init__(self, env: gym.Env) -> None:
         super().__init__(env)
         self._steps : List[StepRecord] = []
-        self._action_wrapper = action_wrapper
 
     def reset(self, **kwargs):
-        # don't save replay on reset
-        self._steps.clear()
+        # if we reset the game without terminating/truncating, only save if we made some progress
+        # we don't need a 0 or 1 step game
+        if len(self._steps) > 1:
+            self._save_replay()
 
         obs, info = self.env.reset(**kwargs)
-        assert len(self._steps) == 0, "Replay steps should be cleared."
-        self.add_step(obs, None, info)
+
+        self._steps.clear()
+        self._steps.append(StepRecord(None, obs, info))
         return obs, info
 
     def step(self, action):
         obs, reward, terminated, truncated, info = self.env.step(action)
-        self.add_step(obs, action, info)
+
+        action_keycode = self.unwrapped.actions[action].value
+        if info['end_status'] == 1: # game_over
+            info_copy = info.copy()
+            info_copy['how_done'] = self.unwrapped.nethack.how_done().name
+            self._steps.append(StepRecord(action_keycode, obs, info_copy))
+        else:
+            self._steps.append(StepRecord(action_keycode, obs, info))
 
         if terminated or truncated:
             self._save_replay()
 
         return obs, reward, terminated, truncated, info
-
-    def add_step(self, obs, action, info):
-        """Add a step to the replay."""
-        if action is not None:
-            action = self._action_wrapper.translate_to_keycode(action)
-        state : NethackState = info["state"]
-
-        step_record = StepRecord(action, state.original.observation, state.original.info, obs, info)
-        self._steps.append(step_record)
 
     def _save_replay(self):
         # Save the replay to a file

--- a/yndf/wrapper_state.py
+++ b/yndf/wrapper_state.py
@@ -20,8 +20,6 @@ class NethackStateWrapper(gym.Wrapper):
 
     def step(self, action):  # type: ignore[override]
         obs, reward, terminated, truncated, info = self.env.step(action)
-
-
         if info['end_status'] == 1: # game_over
             info['ending'] = self.unwrapped.nethack.how_done().name
 


### PR DESCRIPTION
This pull request refactors and simplifies the replay recording mechanism for the NetHack environment, streamlining how game steps are captured and saved. The main changes include removing redundant fields from the `StepRecord`, updating the replay wrapper to work independently of the action wrapper, and ensuring replays are saved only for meaningful games. Additionally, the environment creation logic is updated to more cleanly enable replay saving via a single flag.

**Replay recording and wrapper refactor:**

* [`yndf/replays.py`](diffhunk://#diff-4bbd992370be2e365b217f7d8515e8e86050901b01cde5d965968a9760255866L24-R29): The `StepRecord` class is simplified to only store `action`, `observation`, and `info`, removing the `original_observation`, `model_observation`, `original_info`, and `model_info` fields. Corresponding updates are made to the step sanitization logic. [[1]](diffhunk://#diff-4bbd992370be2e365b217f7d8515e8e86050901b01cde5d965968a9760255866L24-R29) [[2]](diffhunk://#diff-4bbd992370be2e365b217f7d8515e8e86050901b01cde5d965968a9760255866L58-L64)
* [`yndf/wrapper_replay.py`](diffhunk://#diff-9595449e1bccf4e8fd1998383e5a183af69b8bbc0b6146c20085d1c88381af83L3-L42): The `NethackReplayWrapper` no longer requires an `action_wrapper` and now directly translates actions to keycodes. Replay saving is triggered only for games with more than one step, and the wrapper logic is simplified to remove the `add_step` method and related complexity.

**Environment creation and replay activation:**

* [`yndf/__init__.py`](diffhunk://#diff-b17dfb65dab28cd59285c6da7735bf379efc6e7e832a804cf585e86b251f421dL21-R28): The `create_env` function now activates replay saving with a single `save_replays` flag, and the replay wrapper is applied directly without requiring an action wrapper.
* [`debugger.py`](diffhunk://#diff-383932617e06cbf9135383438b904fec34903df77530a4dd5086f3d8f57866faL109-R108): The environment is now created with `save_replays=True` to enable replay recording during debugging sessions.

**Minor adjustments:**

* [`yndf/wrapper_state.py`](diffhunk://#diff-8835c8965b449ba5a423706be07cfee979d04e7bac0652500398e64bf1f4ad8bL23-L24): Minor logic change to add an `ending` key to the `info` dictionary when the game ends, improving end-of-game metadata.
* [`debugger.py`](diffhunk://#diff-383932617e06cbf9135383438b904fec34903df77530a4dd5086f3d8f57866faL46): Minor code cleanup in the controller initialization.